### PR TITLE
ci: update publish workflow for multi-arch Docker builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,11 +2,12 @@ name: Publish
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
       git_tag:
         required: true
+        description: "Git tag to checkout"
         type: string
 env:
   GIT_TAG: ${{ github.event.inputs.git_tag || github.ref_name }}
@@ -26,53 +27,53 @@ jobs:
           ref: ${{ env.GIT_TAG }}
       - name: Test and build extension for Postgres
         run: pg-build-test
-  pgxn-publish:
-    needs: pgxn-test
-    runs-on: ubuntu-latest
-    container:
-      image: pgxn/pgxn-tools
-      env:
-        PGXN_USERNAME: ${{ secrets.PGXN_USERNAME }}
-        PGXN_PASSWORD: ${{ secrets.PGXN_PASSWORD }}
-    steps:
-      - name: Checkout specified tag
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ env.GIT_TAG }}
-      - name: Build the extension bundle
-        run: pgxn-bundle
-      - name: Publish the extension to PGXN
-        run: pgxn-release
   docker-publish:
     needs: pgxn-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout specified tag
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.GIT_TAG }}
+
       - name: Create version tag for Docker image
         run: |
           echo "BUILD_VERSION=$(echo ${GIT_TAG} | sed 's/^v//')" >> $GITHUB_ENV
+
       - name: Login to Github Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push tagged Docker image
-        uses: docker/build-push-action@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
         with:
+          platforms: linux/amd64, linux/arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Build and push tagged Docker image
+        uses: docker/build-push-action@v4
+        with:
+          platforms: linux/amd64, linux/arm64
           context: .
           load: true
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ env.BUILD_VERSION }}
+
       - name: Run Docker image
         run: docker run --name pg_uuidv7 ghcr.io/${{ github.repository }} /bin/sh
+
       - name: Copy Docker container artifacts
         run: docker cp pg_uuidv7:/srv/ ./
+
       - name: Upload the latest artifacts to releases
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
- Add QEMU and Docker Buildx setup for multi-architecture builds
- Update Docker build action to support linux/amd64 and linux/arm64 platforms
- Remove PGXN publishing job
- Update actions to latest versions
- Add description for git_tag input in workflow_dispatch