### PR TITLE
ci: reduce PostgreSQL versions for PGXN testing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
   pgxn-test:
     strategy:
       matrix:
-        pg: [17, 16, 15, 14, 13]
+        pg: [17]
     runs-on: ubuntu-latest
     container: pgxn/pgxn-tools
     steps:


### PR DESCRIPTION
Update the GitHub Actions workflow to only test against PostgreSQL 17 instead of versions 13 through 17. This change streamlines the CI process by focusing on the latest PostgreSQL version.